### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main  # Change this to your default branch
 
+permissions:
+  contents: read
+  pages: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/KennethDoerflein/Tic-Tac-Toe-React/security/code-scanning/1](https://github.com/KennethDoerflein/Tic-Tac-Toe-React/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Since the workflow involves checking out the repository, installing dependencies, building the project, and deploying to GitHub Pages, the `contents: read` and `pages: write` permissions are sufficient. These permissions will allow the workflow to read repository contents and deploy to GitHub Pages without granting unnecessary write access to other resources.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
